### PR TITLE
update scrapeInterval and scrapeTimeout cable&bios

### DIFF
--- a/system/infra-monitoring/values.yaml
+++ b/system/infra-monitoring/values.yaml
@@ -130,22 +130,22 @@ apic_exporters:
 
 bm_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 1m
-  scrapeTimeout: 55s
+  scrapeInterval: 1d
+  scrapeTimeout: 23h50m
 
 vpod_cablecheck_exporter:
   enabled: false
-  scrapeInterval: 1m
-  scrapeTimeout: 55s
+  scrapeInterval: 1d
+  scrapeTimeout: 23h50m
 
 bios_exporter:
   enabled: false
-  ironic_scrapeInterval: 60m
-  ironic_scrapeTimeout: 59m
-  vpod_scrapeInterval: 300s
-  vpod_scrapeTimeout: 290s
-  cisco_cp_scrapeInterval: 120s
-  cisco_cp_scrapeTimeout: 115s
+  ironic_scrapeInterval: 1d
+  ironic_scrapeTimeout: 23h50m
+  vpod_scrapeInterval: 1d
+  vpod_scrapeTimeout: 23h50m
+  cisco_cp_scrapeInterval: 1d
+  cisco_cp_scrapeTimeout: 23h50m
 
 vcenter-exporters:
   enabled: false


### PR DESCRIPTION
Too many requests on remote boards. Therefore, reduced interval of BIOS and CABLECHECK exporters.